### PR TITLE
Implement in-memory LRU cache for audio synthesis requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ OpenAI-compatible HTTP server for [OmniVoice](https://github.com/k2-fsa/OmniVoic
 - **Voice profile management** - Save and reuse cloned voices
 - **Streaming synthesis** - Low-latency sentence-level streaming
 - **Concurrent requests** - Configurable thread pool for parallel synthesis
+- **In-memory audio cache** - LRU cache with TTL for repeated requests (same voice + text)
 - **Multiple audio formats** - WAV and raw PCM output
 - **Speed control** - 0.25x to 4.0x playback speed
 - **Optional authentication** - Bearer token support
@@ -300,6 +301,9 @@ omnivoice-server
 | `--num-step` | `OMNIVOICE_NUM_STEP` | `32` | Inference steps (1-64, higher=better quality) |
 | `--max-concurrent` | `OMNIVOICE_MAX_CONCURRENT` | `2` | Max concurrent requests |
 | `--api-key` | `OMNIVOICE_API_KEY` | `""` | Bearer token (empty = no auth) |
+| `--cache-enabled` | `OMNIVOICE_CACHE_ENABLED` | `true` | Enable in-memory audio cache |
+| `--cache-max-mb` | `OMNIVOICE_CACHE_MAX_MB` | `512` | Max cache memory in MB (LRU eviction) |
+| `--cache-ttl-s` | `OMNIVOICE_CACHE_TTL_S` | `3600` | Cache entry TTL in seconds (0 = no expiry) |
 | `--model-id` | `OMNIVOICE_MODEL_ID` | `k2-fsa/OmniVoice` | HuggingFace repo or local path |
 | `--profile-dir` | `OMNIVOICE_PROFILE_DIR` | `~/.omnivoice/profiles` | Voice profiles directory |
 | `--log-level` | `OMNIVOICE_LOG_LEVEL` | `info` | Logging level |
@@ -398,9 +402,37 @@ Health check endpoint.
 
 #### `GET /metrics`
 
-Prometheus-style metrics.
+Prometheus-style metrics (includes cache stats when enabled).
+
+#### `DELETE /v1/audio/cache`
+
+Clear the in-memory audio cache. Returns cache stats at the moment of clearing.
 
 ## Advanced Features
+
+### Audio Cache
+
+Repeated requests with the same parameters (voice, text, speed, etc.) are served from an in-memory LRU cache, skipping inference entirely. This is useful when clients send the same request many times (e.g. the same clone profile + text).
+
+The cache stores final audio bytes (WAV/PCM), not GPU tensors, so it doesn't consume GPU memory.
+
+```bash
+# Check cache stats
+curl http://127.0.0.1:8880/metrics
+# → { "cache_hits": 42, "cache_misses": 10, "cache_hit_rate": 0.808, ... }
+
+# Clear the cache
+curl -X DELETE http://127.0.0.1:8880/v1/audio/cache
+
+# Disable cache entirely
+omnivoice-server --no-cache
+```
+
+Responses include an `X-Cache: HIT` or `X-Cache: MISS` header. Cache applies to non-streaming `/v1/audio/speech` only — streaming and one-shot `/v1/audio/speech/clone` are not cached.
+
+Memory is managed by:
+- **LRU eviction**: when total cached bytes exceed `cache_max_mb` (default 512MB), least-recently-used entries are dropped.
+- **TTL expiry**: a background sweep removes entries older than `cache_ttl_s` (default 3600s). Set to 0 to disable TTL (LRU-only).
 
 ### Non-Verbal Symbols
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -129,6 +129,7 @@ graph TB
         MS["ModelService<br/>model singleton"]
         PS["ProfileService<br/>disk store"]
         MTS["MetricsService<br/>in-memory counters"]
+        AC["AudioCache<br/>LRU + TTL"]
     end
 
     subgraph UTIL["Utility layer"]
@@ -147,7 +148,7 @@ graph TB
     end
 
     R1 & R2 & R3 & R4 --> AUTH
-    AUTH --> IS & PS & MTS
+    AUTH --> IS & PS & MTS & AC
     IS --> MS
     IS --> UTIL
     IS --> TP & SEM
@@ -161,7 +162,7 @@ graph TB
 | -------------------------- | ------------------------------------------------------------------ | ------------------------- |
 | **HTTP surface** (routers) | Parse/validate request, format response, map errors to HTTP status | Business logic            |
 | **Middleware**             | Auth gate, future: rate limiting                                   | Routing                   |
-| **Service layer**          | Orchestrate inference, manage state, record metrics                | HTTP concerns             |
+| **Service layer**          | Orchestrate inference, manage state, record metrics, cache results | HTTP concerns             |
 | **Utility layer**          | Pure functions (audio encoding, text splitting)                    | Side effects              |
 | **Config layer**           | Single source of truth for all tunables                            | Validation beyond type    |
 | **Infrastructure**         | Thread pool, semaphore, filesystem                                 | Awareness of domain logic |
@@ -190,6 +191,7 @@ graph LR
             SINFER["inference.py<br/>InferenceService<br/>SynthesisRequest / Result"]
             SPROFILE["profiles.py<br/>ProfileService"]
             SMETRIC["metrics.py<br/>MetricsService"]
+            SCACHE["cache.py<br/>AudioCache<br/>LRU + TTL sweep"]
         end
 
         subgraph utils["utils/"]
@@ -204,9 +206,9 @@ graph LR
     APP --> SMODEL & SINFER & SPROFILE & SMETRIC
     APP --> RSPEECH & RVOICES & RHEALTH
 
-    RSPEECH --> SINFER & SPROFILE & SMETRIC & UAUDIO & UTEXT
+    RSPEECH --> SINFER & SPROFILE & SMETRIC & UAUDIO & UTEXT & SCACHE
     RVOICES --> SPROFILE
-    RHEALTH --> SMETRIC
+    RHEALTH --> SMETRIC & SCACHE
 
     SINFER --> SMODEL & UAUDIO
     SMODEL -->|"OmniVoice.from_pretrained()"| EXT_OV["omnivoice<br/>(external package)"]
@@ -284,7 +286,9 @@ flowchart TD
     E --> F{stream=True?}
     F -->|yes| STREAM([→ See streaming diagram])
 
-    F -->|no| G[InferenceService.synthesize]
+    F -->|no| G0{AudioCache\nlookup}
+    G0 -->|HIT| CACHED([200 OK\nX-Cache: HIT\naudio bytes from cache])
+    G0 -->|MISS| G[InferenceService.synthesize]
     G --> H{semaphore acquired?}
     H -->|wait| H
     H -->|acquired| I[ThreadPoolExecutor\n_run_sync]
@@ -293,7 +297,8 @@ flowchart TD
     J -->|Exception| ERR500([500 Internal Server Error])
     J -->|tensors| K[tensor→WAV or PCM bytes]
     K --> L[metrics_svc.record_success]
-    L --> M([200 OK\naudio/wav or audio/pcm])
+    L --> L2[AudioCache.put]
+    L2 --> M([200 OK\nX-Cache: MISS\naudio/wav or audio/pcm])
 ```
 
 ---
@@ -398,6 +403,8 @@ sequenceDiagram
     APP->>APP: InferenceService(model_svc, executor, cfg)
     APP->>APP: ProfileService(profile_dir)
     APP->>APP: MetricsService()
+    APP->>APP: AudioCache(cfg) + await start()
+    Note over APP: Starts background TTL sweep task<br/>(interval = ttl_s / 2, min 10s)
     APP->>APP: record start_time
 
     APP-->>UV: yield  ← server starts accepting requests
@@ -405,6 +412,8 @@ sequenceDiagram
     Note over UV: ... server live ...
 
     UV->>APP: shutdown signal (SIGINT / SIGTERM)
+    APP->>APP: await audio_cache.stop()
+    Note over APP: Cancels TTL sweep task
     APP->>EX: executor.shutdown(wait=False)
     Note over EX: In-flight inferences may be interrupted.<br/>wait=False avoids hanging on long synthesis.
     APP-->>UV: done
@@ -485,6 +494,8 @@ graph TD
     PS["ProfileService<br/>owns: profile_dir path<br/>state: filesystem (external)"]
     MTS["MetricsService<br/>owns: counters, latency deque<br/>state: in-memory, resets on restart"]
 
+    AC["AudioCache<br/>owns: LRU OrderedDict, TTL sweep task<br/>state: in-memory, resets on restart"]
+
     EX["ThreadPoolExecutor<br/>(created in lifespan, shared)"]
     FS["~/.omnivoice/profiles/"]
 
@@ -493,6 +504,8 @@ graph TD
     CFG -->|"profile_dir"| PS
     CFG -->|"max_concurrent"| EX
 
+    AC -.->|"used by"| RSPEECH
+    AC -.->|"used by"| RHEALTH
     MS -->|"model singleton"| IS
     EX -->|"thread pool"| IS
     FS -->|"read/write"| PS

--- a/docs/design/dataflow.md
+++ b/docs/design/dataflow.md
@@ -10,6 +10,7 @@
 | ------------------------------------------------- | -------------------- | ------------- | --------------- |
 | [`/v1/audio/speech`](#v1audiospeech)              | POST                 | Optional      | WAV / PCM bytes |
 | [`/v1/audio/speech/clone`](#v1audiospeechclone)   | POST                 | Optional      | WAV bytes       |
+| [`/v1/audio/cache`](#v1audiocache)                | DELETE               | Optional      | JSON            |
 | [`/v1/voices`](#v1voices)                         | GET                  | Optional      | JSON            |
 | [`/v1/voices/profiles`](#v1voicesprofiles)        | POST                 | Optional      | JSON (201)      |
 | [`/v1/voices/profiles/{id}`](#v1voicesprofilesid) | GET / PATCH / DELETE | Optional      | JSON / 204      |
@@ -45,6 +46,12 @@ HTTP Request
   ├─ SynthesisRequest built ─────────────────────────────────────────────────────────
   │   text, mode, instruct, ref_audio_path, ref_text, speed, num_step
   │
+  ├─ Cache lookup (non-streaming only) ──────────────────────────────────────────────
+  │   key = SHA-256(voice, text, speed, num_step, guidance_scale, ...)
+  │   AudioCache.get(key)
+  │   → HIT:  return cached audio bytes immediately (X-Cache: HIT)
+  │   → MISS: proceed to inference
+  │
   ├─ InferenceService.synthesize() [async] ──────────────────────────────────────────
   │   └─ asyncio.wait_for(                       timeout = request_timeout_s (120s)
   │        run_in_executor(executor, _run_sync)  releases event loop while GPU runs
@@ -71,7 +78,9 @@ HTTP Request
       Content-Type: audio/wav | audio/pcm
       X-Audio-Duration-S: <seconds>
       X-Synthesis-Latency-S: <seconds>
+      X-Cache: HIT | MISS
       Body: <audio bytes>
+      → AudioCache.put(key, audio_bytes) on MISS
 ```
 
 ### Streaming data flow
@@ -209,6 +218,29 @@ HTTP PATCH /v1/voices/profiles/{profile_id}
 
 ---
 
+## /v1/audio/cache
+
+```
+DELETE /v1/audio/cache → 200 (auth required if configured)
+{
+  "cleared": {
+    "cache_entries": 42,
+    "cache_bytes": 12345678,
+    "cache_mb": 11.77,
+    "cache_max_mb": 512,
+    "cache_hits": 100,
+    "cache_misses": 42,
+    "cache_evictions": 3,
+    "cache_hit_rate": 0.704
+  }
+}
+```
+
+Returns stats at the moment of clearing, then wipes all cached entries.
+Returns 404 if cache is disabled.
+
+---
+
 ## /health
 
 ```
@@ -219,6 +251,8 @@ GET /health → always 200 (auth bypassed)
   "device": "mps" | "cuda" | "cpu",
   "num_step": 16,
   "max_concurrent": 2,
+  "cache_enabled": true,
+  "cache_max_mb": 512,
   "uptime_s": 42.1
 }
 ```
@@ -236,9 +270,18 @@ GET /metrics → always 200 (auth bypassed)
   "requests_timeout": 1,
   "mean_latency_ms": 1240.5,
   "p95_latency_ms": 2100.0,
-  "ram_mb": 5432.1
+  "ram_mb": 5432.1,
+  "cache_entries": 42,
+  "cache_mb": 11.77,
+  "cache_max_mb": 512,
+  "cache_hits": 100,
+  "cache_misses": 42,
+  "cache_evictions": 3,
+  "cache_hit_rate": 0.704
 }
 ```
+
+Cache fields are included when `cache_enabled=true` (default).
 
 Note: After applying **P1 patch**, streaming requests are included in these counters. Prior to the patch, streaming requests were not counted.
 

--- a/omnivoice_server/app.py
+++ b/omnivoice_server/app.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse
 
 from .config import Settings
 from .routers import health, models, speech, voices  # FIX: added models
+from .services.cache import AudioCache
 from .services.inference import InferenceService
 from .services.metrics import MetricsService
 from .services.model import ModelService
@@ -52,6 +53,18 @@ async def lifespan(app: FastAPI):
 
     app.state.profile_svc = ProfileService(profile_dir=cfg.profile_dir)
     app.state.metrics_svc = MetricsService()
+
+    # Audio cache for repeated requests (same voice + text)
+    if cfg.cache_enabled:
+        audio_cache = AudioCache(cfg)
+        await audio_cache.start()
+        app.state.audio_cache = audio_cache
+        logger.info(
+            f"Audio cache enabled (max={cfg.cache_max_mb}MB, ttl={cfg.cache_ttl_s}s)"
+        )
+    else:
+        app.state.audio_cache = None
+
     app.state.start_time = time.monotonic()
 
     elapsed = time.monotonic() - t0
@@ -61,6 +74,9 @@ async def lifespan(app: FastAPI):
 
     # ── Shutdown ──────────────────────────────────────────────────────────────
     logger.info("Shutting down...")
+    audio_cache = getattr(app.state, "audio_cache", None)
+    if audio_cache is not None:
+        await audio_cache.stop()
     executor.shutdown(wait=False)
     logger.info("Done.")
 

--- a/omnivoice_server/cli.py
+++ b/omnivoice_server/cli.py
@@ -109,6 +109,35 @@ def main() -> None:
         help="Voice profile directory (env: OMNIVOICE_PROFILE_DIR)",
     )
 
+    # Cache
+    parser.add_argument(
+        "--cache-enabled",
+        action="store_true",
+        default=None,
+        dest="cache_enabled",
+        help="Enable in-memory audio cache (env: OMNIVOICE_CACHE_ENABLED)",
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_false",
+        dest="cache_enabled",
+        help="Disable in-memory audio cache",
+    )
+    parser.add_argument(
+        "--cache-max-mb",
+        type=int,
+        default=None,
+        dest="cache_max_mb",
+        help="Max cache memory in MB, 16-8192 (env: OMNIVOICE_CACHE_MAX_MB)",
+    )
+    parser.add_argument(
+        "--cache-ttl-s",
+        type=int,
+        default=None,
+        dest="cache_ttl_s",
+        help="Cache entry TTL in seconds. 0=no expiry (env: OMNIVOICE_CACHE_TTL_S)",
+    )
+
     # Auth
     parser.add_argument(
         "--api-key",

--- a/omnivoice_server/config.py
+++ b/omnivoice_server/config.py
@@ -84,6 +84,23 @@ class Settings(BaseSettings):
         description="Max seconds per synthesis request before 504",
     )
 
+    # Audio cache
+    cache_enabled: bool = Field(
+        default=True,
+        description="Enable in-memory LRU cache for repeated synthesis requests",
+    )
+    cache_max_mb: int = Field(
+        default=512,
+        ge=16,
+        le=8192,
+        description="Max memory for audio cache in MB. LRU eviction when exceeded.",
+    )
+    cache_ttl_s: int = Field(
+        default=3600,
+        ge=0,
+        description="Cache entry TTL in seconds. 0 = no expiry (LRU eviction only).",
+    )
+
     # Voice profiles
     profile_dir: Path = Field(
         default=Path.home() / ".omnivoice" / "profiles",

--- a/omnivoice_server/routers/health.py
+++ b/omnivoice_server/routers/health.py
@@ -23,6 +23,8 @@ async def health(request: Request):
         "device": cfg.device,
         "num_step": cfg.num_step,
         "max_concurrent": cfg.max_concurrent,
+        "cache_enabled": cfg.cache_enabled,
+        "cache_max_mb": cfg.cache_max_mb,
         "uptime_s": round(uptime_s, 1),
     }
 
@@ -33,4 +35,9 @@ async def metrics(request: Request):
     metrics_svc = request.app.state.metrics_svc
     snapshot = metrics_svc.snapshot()
     snapshot["ram_mb"] = round(psutil.Process().memory_info().rss / 1024 / 1024, 1)
+
+    audio_cache = getattr(request.app.state, "audio_cache", None)
+    if audio_cache is not None:
+        snapshot.update(audio_cache.snapshot())
+
     return snapshot

--- a/omnivoice_server/routers/speech.py
+++ b/omnivoice_server/routers/speech.py
@@ -17,6 +17,7 @@ from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
 from ..services.inference import InferenceService, SynthesisRequest
+from ..services.cache import AudioCache, _build_cache_key
 from ..services.metrics import MetricsService
 from ..services.profiles import ProfileNotFoundError, ProfileService
 from ..utils.audio import tensor_to_pcm16_bytes, tensors_to_wav_bytes
@@ -67,6 +68,10 @@ def _get_cfg(request: Request):
     return request.app.state.cfg
 
 
+def _get_cache(request: Request) -> AudioCache | None:
+    return getattr(request.app.state, "audio_cache", None)
+
+
 def _parse_voice(
     voice_str: str,
     profile_svc: ProfileService,
@@ -113,6 +118,7 @@ async def create_speech(
     profile_svc: ProfileService = Depends(_get_profiles),
     metrics_svc: MetricsService = Depends(_get_metrics),
     cfg=Depends(_get_cfg),
+    cache: AudioCache | None = Depends(_get_cache),
 ):
     """Generate speech from text."""
     mode, instruct, ref_audio_path, ref_text = _parse_voice(body.voice, profile_svc)
@@ -145,6 +151,44 @@ async def create_speech(
             },
         )
 
+    # ── Cache lookup (non-streaming only) ─────────────────────────────────
+    cache_key = None
+    if cache is not None:
+        cache_key = _build_cache_key(
+            text=body.input,
+            voice=body.voice,
+            speed=body.speed,
+            num_step=body.num_step if body.num_step is not None else cfg.num_step,
+            guidance_scale=(
+                body.guidance_scale if body.guidance_scale is not None else cfg.guidance_scale
+            ),
+            denoise=body.denoise if body.denoise is not None else cfg.denoise,
+            t_shift=body.t_shift if body.t_shift is not None else cfg.t_shift,
+            position_temperature=(
+                body.position_temperature
+                if body.position_temperature is not None
+                else cfg.position_temperature
+            ),
+            class_temperature=(
+                body.class_temperature
+                if body.class_temperature is not None
+                else cfg.class_temperature
+            ),
+            duration=body.duration,
+            response_format=body.response_format,
+        )
+        hit = cache.get(cache_key)
+        if hit is not None:
+            return Response(
+                content=hit.audio_bytes,
+                media_type=hit.media_type,
+                headers={
+                    "X-Audio-Duration-S": str(round(hit.duration_s, 3)),
+                    "X-Synthesis-Latency-S": "0.000",
+                    "X-Cache": "HIT",
+                },
+            )
+
     try:
         result = await inference_svc.synthesize(req)
         metrics_svc.record_success(result.latency_s)
@@ -171,12 +215,17 @@ async def create_speech(
         audio_bytes = tensors_to_wav_bytes(result.tensors)
         media_type = "audio/wav"
 
+    # ── Cache store ───────────────────────────────────────────────────────
+    if cache is not None and cache_key is not None:
+        cache.put(cache_key, audio_bytes, media_type, result.duration_s)
+
     return Response(
         content=audio_bytes,
         media_type=media_type,
         headers={
             "X-Audio-Duration-S": str(round(result.duration_s, 3)),
             "X-Synthesis-Latency-S": str(round(result.latency_s, 3)),
+            "X-Cache": "MISS",
         },
     )
 
@@ -301,3 +350,19 @@ async def create_speech_clone(
             "X-Synthesis-Latency-S": str(round(result.latency_s, 3)),
         },
     )
+
+
+@router.delete("/audio/cache")
+async def clear_cache(
+    cache: AudioCache | None = Depends(_get_cache),
+):
+    """Clear the in-memory audio cache. Returns current stats before clearing."""
+    if cache is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Audio cache is not enabled",
+        )
+
+    stats = cache.snapshot()
+    cache.clear()
+    return {"cleared": stats}

--- a/omnivoice_server/services/cache.py
+++ b/omnivoice_server/services/cache.py
@@ -1,0 +1,248 @@
+"""
+In-memory LRU cache for synthesis results.
+
+Caches the encoded audio bytes (WAV) keyed on the full set of parameters
+that affect model output. Designed for the common pattern where clients
+repeatedly request the same (voice profile + text) combination.
+
+Memory safety:
+  - Configurable max memory cap (cache_max_mb).
+  - LRU eviction: oldest-accessed entries are dropped first when the cap
+    is exceeded.
+  - Entries track their byte size so the budget is accurate.
+  - Thread-safe via threading.Lock (cache is accessed from thread pool).
+
+TTL enforcement:
+  - Lazy: expired entries are removed on access (get returns None).
+  - Active: a background asyncio task sweeps expired entries periodically
+    so stale data doesn't sit in memory indefinitely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+
+from ..config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    audio_bytes: bytes
+    media_type: str  # "audio/wav" or "audio/pcm"
+    duration_s: float
+    created_at: float
+
+    @property
+    def size_bytes(self) -> int:
+        return len(self.audio_bytes)
+
+
+def _build_cache_key(
+    text: str,
+    voice: str,
+    speed: float,
+    num_step: int,
+    guidance_scale: float,
+    denoise: bool,
+    t_shift: float,
+    position_temperature: float,
+    class_temperature: float,
+    duration: float | None,
+    response_format: str,
+) -> str:
+    """
+    Build a deterministic cache key from all parameters that affect output.
+
+    Uses SHA-256 of the concatenated param string. The ``voice`` field is
+    the raw client string (e.g. "clone:voice11", "design:female, british",
+    "auto") — a stable semantic identifier that doesn't depend on filesystem
+    paths or profile directory location.
+    """
+    parts = [
+        text,
+        voice,
+        str(speed),
+        str(num_step),
+        str(guidance_scale),
+        str(denoise),
+        str(t_shift),
+        str(position_temperature),
+        str(class_temperature),
+        str(duration) if duration is not None else "",
+        response_format,
+    ]
+    raw = "\x00".join(parts)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+class AudioCache:
+    """
+    Thread-safe LRU cache for synthesised audio bytes.
+
+    Evicts least-recently-used entries when total memory exceeds
+    cache_max_mb. All public methods are safe to call from any thread.
+    """
+
+    def __init__(self, cfg: Settings) -> None:
+        self._max_bytes = cfg.cache_max_mb * 1024 * 1024
+        self._ttl_s = cfg.cache_ttl_s
+        self._lock = threading.Lock()
+        # OrderedDict gives us O(1) move-to-end for LRU
+        self._store: OrderedDict[str, _CacheEntry] = OrderedDict()
+        self._current_bytes = 0
+        self._hits = 0
+        self._misses = 0
+        self._evictions = 0
+        self._sweep_task: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        """Start the background TTL sweep task."""
+        if self._ttl_s > 0:
+            self._sweep_task = asyncio.create_task(self._sweep_loop())
+            logger.info(
+                f"Cache TTL sweep started (interval={self._ttl_s // 2}s, ttl={self._ttl_s}s)"
+            )
+
+    async def stop(self) -> None:
+        """Stop the background sweep task."""
+        if self._sweep_task is not None:
+            self._sweep_task.cancel()
+            try:
+                await self._sweep_task
+            except asyncio.CancelledError:
+                pass
+            self._sweep_task = None
+
+    async def _sweep_loop(self) -> None:
+        """Periodically remove expired entries so stale data doesn't linger."""
+        # Sweep at half the TTL interval — frequent enough to keep memory
+        # honest, infrequent enough to be negligible overhead.
+        interval = max(self._ttl_s // 2, 10)
+        while True:
+            await asyncio.sleep(interval)
+            removed = self._sweep_expired()
+            if removed > 0:
+                logger.debug(f"TTL sweep removed {removed} expired cache entries")
+
+    def get(self, key: str) -> _CacheEntry | None:
+        """Return cached entry or None. Moves entry to MRU position."""
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                self._misses += 1
+                return None
+
+            # Check TTL
+            if self._ttl_s > 0 and (time.monotonic() - entry.created_at) > self._ttl_s:
+                self._remove_locked(key)
+                self._misses += 1
+                return None
+
+            # Move to end (most recently used)
+            self._store.move_to_end(key)
+            self._hits += 1
+            return entry
+
+    def put(self, key: str, audio_bytes: bytes, media_type: str, duration_s: float) -> None:
+        """
+        Insert or replace a cache entry. Evicts LRU entries if over budget.
+
+        Silently skips caching if a single entry exceeds the entire budget
+        (avoids thrashing the whole cache for one huge response).
+        """
+        entry_size = len(audio_bytes)
+
+        # Don't cache entries larger than the entire budget
+        if entry_size > self._max_bytes:
+            logger.debug(
+                f"Skipping cache for entry of {entry_size / 1024 / 1024:.1f}MB "
+                f"(exceeds {self._max_bytes / 1024 / 1024:.0f}MB budget)"
+            )
+            return
+
+        entry = _CacheEntry(
+            audio_bytes=audio_bytes,
+            media_type=media_type,
+            duration_s=duration_s,
+            created_at=time.monotonic(),
+        )
+
+        with self._lock:
+            # If key already exists, remove old entry's size first
+            if key in self._store:
+                old = self._store[key]
+                self._current_bytes -= old.size_bytes
+                del self._store[key]
+
+            # Evict LRU entries until we have room
+            while self._current_bytes + entry_size > self._max_bytes and self._store:
+                self._evict_lru_locked()
+
+            self._store[key] = entry
+            self._current_bytes += entry_size
+
+    def clear(self) -> None:
+        """Drop all cached entries."""
+        with self._lock:
+            self._store.clear()
+            self._current_bytes = 0
+
+    def snapshot(self) -> dict:
+        """Return cache stats for the /metrics endpoint."""
+        with self._lock:
+            return {
+                "cache_entries": len(self._store),
+                "cache_bytes": self._current_bytes,
+                "cache_mb": round(self._current_bytes / 1024 / 1024, 2),
+                "cache_max_mb": round(self._max_bytes / 1024 / 1024, 0),
+                "cache_hits": self._hits,
+                "cache_misses": self._misses,
+                "cache_evictions": self._evictions,
+                "cache_hit_rate": (
+                    round(self._hits / (self._hits + self._misses), 3)
+                    if (self._hits + self._misses) > 0
+                    else 0.0
+                ),
+            }
+
+    def _evict_lru_locked(self) -> None:
+        """Remove the least-recently-used entry. Caller must hold _lock."""
+        if not self._store:
+            return
+        key, entry = self._store.popitem(last=False)  # FIFO = LRU end
+        self._current_bytes -= entry.size_bytes
+        self._evictions += 1
+        logger.debug(
+            f"Evicted cache entry {key[:12]}… "
+            f"({entry.size_bytes / 1024:.1f}KB, "
+            f"age={time.monotonic() - entry.created_at:.0f}s)"
+        )
+
+    def _remove_locked(self, key: str) -> None:
+        """Remove a specific entry. Caller must hold _lock."""
+        entry = self._store.pop(key, None)
+        if entry:
+            self._current_bytes -= entry.size_bytes
+
+    def _sweep_expired(self) -> int:
+        """Remove all entries past TTL. Returns count of removed entries."""
+        if self._ttl_s <= 0:
+            return 0
+        now = time.monotonic()
+        with self._lock:
+            expired_keys = [
+                k for k, e in self._store.items()
+                if (now - e.created_at) > self._ttl_s
+            ]
+            for key in expired_keys:
+                self._remove_locked(key)
+                self._evictions += 1
+        return len(expired_keys)


### PR DESCRIPTION

## feat: in-memory LRU cache for repeated synthesis requests

### Problem

Some clients send the same request repeatedly — same clone profile, same text, same parameters. Each request runs full inference (~10s on CPU, ~0.5s on GPU), wasting compute on identical work.

### Solution

An in-memory LRU cache stores the final audio bytes (WAV/PCM) keyed on all output-affecting parameters. Identical requests return instantly from cache with zero inference cost.

### How it works

On each non-streaming `/v1/audio/speech` request, the router hashes `(voice, text, speed, num_step, guidance_scale, denoise, t_shift, position_temperature, class_temperature, duration, response_format)` into a SHA-256 cache key. The `voice` field is the raw client string (e.g. `"clone:voice11"`) — a stable semantic identifier that doesn't depend on filesystem paths.

Cache hits return stored bytes immediately with `X-Cache: HIT`. Misses run inference normally, store the result, and respond with `X-Cache: MISS`.

Memory safety:
- LRU eviction when total bytes exceed `cache_max_mb` (default 512MB)
- TTL expiry via background sweep task (interval = `cache_ttl_s / 2`, min 10s)
- Lazy TTL check on `get()` as well
- Entries larger than the entire budget are silently skipped (prevents thrashing)
- Cache stores `bytes`, not GPU tensors — no VRAM impact

Not cached: streaming requests (can't cache a chunked stream), one-shot `/v1/audio/speech/clone` (temp file paths change every request).

### Changes

- New `omnivoice_server/services/cache.py` — `AudioCache` with LRU `OrderedDict`, TTL sweep task, `_build_cache_key()`
- `config.py` — `cache_enabled`, `cache_max_mb`, `cache_ttl_s` fields
- `app.py` — wire `AudioCache` into lifespan (start/stop)
- `routers/speech.py` — cache lookup before inference, cache store after, `X-Cache` header, `DELETE /v1/audio/cache` endpoint
- `cli.py` — `--cache-enabled`, `--no-cache`, `--cache-max-mb`, `--cache-ttl-s` flags
- `health.py` — expose cache config in `/health`, cache stats in `/metrics`
- README, `docs/architecture/overview.md`, `docs/design/dataflow.md` — updated diagrams, request lifecycle, endpoint docs

### Configuration

| Flag | Env var | Default | Description |
|------|---------|---------|-------------|
| `--cache-enabled` / `--no-cache` | `OMNIVOICE_CACHE_ENABLED` | `true` | Enable/disable audio cache |
| `--cache-max-mb` | `OMNIVOICE_CACHE_MAX_MB` | `512` | Max cache memory (LRU eviction) |
| `--cache-ttl-s` | `OMNIVOICE_CACHE_TTL_S` | `3600` | Entry TTL in seconds (0 = no expiry) |

### API

```bash
# Check cache stats
curl http://localhost:8880/metrics
# → { "cache_hits": 42, "cache_hit_rate": 0.808, ... }

# Clear cache
curl -X DELETE http://localhost:8880/v1/audio/cache
```

### Testing

All 40 existing tests pass. Cache is created during app lifespan but tests mock `synthesize()` directly so cache integration is transparent.