### PR TITLE
fix(ci): resolve mypy and ruff lint errors

### DIFF
--- a/omnivoice_server/app.py
+++ b/omnivoice_server/app.py
@@ -158,7 +158,7 @@ def create_app(cfg: Settings) -> FastAPI:
         # Use mode='json' to ensure all values are JSON-serializable
         # (avoids ValueError objects in 'ctx' from field_validator)
         try:
-            errors = exc.errors(include_url=False)
+            errors = exc.errors()
             # Ensure ctx values are strings
             for err in errors:
                 if "ctx" in err:

--- a/omnivoice_server/routers/speech.py
+++ b/omnivoice_server/routers/speech.py
@@ -102,7 +102,10 @@ def _resolve_synthesis_mode(
 ) -> tuple[str, str | None, str | None, str | None]:
     """Resolve synthesis mode for /v1/audio/speech."""
     logger.debug(
-        f"[TRACE] _resolve_synthesis_mode called: speaker={body.speaker!r}, voice={body.voice!r}, instructions={body.instructions!r}"
+        "[TRACE] _resolve_synthesis_mode called: speaker=%r, voice=%r, instructions=%r",
+        body.speaker,
+        body.voice,
+        body.instructions,
     )
     speaker_raw = body.speaker.strip() if body.speaker else None
     voice_raw = body.voice.strip() if body.voice else None
@@ -118,7 +121,7 @@ def _resolve_synthesis_mode(
         voice_clone = voice_raw.lower().startswith("clone:")
         if speaker_clone != voice_clone:
             logger.warning(
-                "[TRACE] Ambiguous voice request: speaker=%r voice=%r mix clone/non-clone semantics",
+                "[TRACE] Ambiguous voice request: speaker=%r, voice=%r mix clone/non-clone",
                 body.speaker,
                 body.voice,
             )
@@ -156,7 +159,9 @@ def _resolve_synthesis_mode(
             ref_audio_path = profile_svc.get_ref_audio_path(profile_id)
             ref_text = profile_svc.get_ref_text(profile_id)
             logger.info(
-                f"[TRACE] Resolved to CLONE mode: profile_id={profile_id!r}, ref_audio={ref_audio_path}"
+                "[TRACE] Resolved to CLONE mode: profile_id=%r, ref_audio=%s",
+                profile_id,
+                ref_audio_path,
             )
             return "clone", None, str(ref_audio_path), ref_text
         except ProfileNotFoundError:
@@ -173,13 +178,14 @@ def _resolve_synthesis_mode(
 
     if speaker_raw and not speaker_preset and not speaker_raw.lower().startswith("clone:"):
         logger.warning(
-            "[TRACE] Unrecognized speaker field value=%r; speaker is reserved for preset/clone compatibility",
+            "[TRACE] Unrecognized speaker value=%r; use preset/clone or omit",
             body.speaker,
         )
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=(
-                f"Unsupported speaker value '{body.speaker}'. Use a known preset, clone:<profile_id>, "
+                f"Unsupported speaker value '{body.speaker}'. "
+                "Use a known preset, clone:<profile_id>, "
                 "or omit `speaker` and use `voice`/`instructions`."
             ),
         )
@@ -198,14 +204,18 @@ def _resolve_synthesis_mode(
     if speaker_preset:
         preset_instruct = speaker_preset
         logger.info(
-            f"[TRACE] Resolved to DESIGN mode (speaker preset): speaker={speaker_key!r} -> {preset_instruct}"
+            "[TRACE] Resolved to DESIGN (speaker preset): speaker=%r -> %s",
+            speaker_key,
+            preset_instruct,
         )
         return "design", preset_instruct, None, None
 
     if voice_preset:
         preset_instruct = voice_preset
         logger.info(
-            f"[TRACE] Resolved to DESIGN mode (voice preset): voice={voice_key!r} -> {preset_instruct}"
+            "[TRACE] Resolved to DESIGN (voice preset): voice=%r -> %s",
+            voice_key,
+            preset_instruct,
         )
         return "design", preset_instruct, None, None
 
@@ -231,7 +241,8 @@ def _resolve_synthesis_mode(
                 raise HTTPException(
                     status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                     detail=(
-                        f"Unsupported voice value '{body.voice}'. Use a known preset, clone:<profile_id>, "
+                        f"Unsupported voice value '{body.voice}'. "
+                        "Use a known preset, clone:<profile_id>, "
                         "or supported design attributes from /v1/voices."
                     ),
                 ) from e

--- a/omnivoice_server/services/inference.py
+++ b/omnivoice_server/services/inference.py
@@ -135,7 +135,9 @@ class OmniVoiceAdapter:
             if req.ref_text:
                 kwargs["ref_text"] = req.ref_text
             logger.info(
-                f"[TRACE] CLONE mode kwargs prepared: ref_audio={req.ref_audio_path}, ref_text={req.ref_text!r}"
+                "[TRACE] CLONE mode kwargs prepared: ref_audio=%s, ref_text=%r",
+                req.ref_audio_path,
+                req.ref_text,
             )
         else:
             logger.warning(f"[TRACE] Unknown/unsupported mode: {req.mode!r}")

--- a/omnivoice_server/services/script.py
+++ b/omnivoice_server/services/script.py
@@ -175,14 +175,19 @@ class ScriptOrchestrator:
         _logger = logging.getLogger(__name__)
 
         _logger.debug(
-            f"[TRACE] _resolve_voices called: {len(segments)} segments, default_voice={default_voice!r}"
+            "[TRACE] _resolve_voices called: %d segments, default_voice=%r",
+            len(segments),
+            default_voice,
         )
         speaker_voices: dict[str, ResolvedVoice] = {}
 
         for segment in segments:
             speaker = segment.speaker
             _logger.debug(
-                f"[TRACE] Processing segment index={segment.index}, speaker={speaker!r}, voice={segment.voice!r}"
+                "[TRACE] Segment index=%d, speaker=%r, voice=%r",
+                segment.index,
+                speaker,
+                segment.voice,
             )
 
             # Skip if already resolved
@@ -247,7 +252,10 @@ class ScriptOrchestrator:
             if bare_preset:
                 speaker_voices[speaker] = ResolvedVoice(kind="design", value=bare_preset)
                 _logger.info(
-                    f"[TRACE] Speaker {speaker!r} resolved to bare OpenAI preset {voice!r} -> {bare_preset}"
+                    "[TRACE] Speaker %r resolved to bare preset %r -> %s",
+                    speaker,
+                    voice,
+                    bare_preset,
                 )
                 continue
 
@@ -261,23 +269,32 @@ class ScriptOrchestrator:
                 raise HTTPException(
                     status_code=422,
                     detail=(
-                        f"Unsupported voice value '{voice}' for speaker '{speaker}'. "
-                        "Use a known preset, openai:<preset>, clone:<profile_id>, or supported design attributes."
+                        f"Unsupported voice '{voice}' for speaker '{speaker}'. "
+                        "Use a known preset, openai:<preset>, clone:<profile_id>, "
+                        "or supported design attributes."
                     ),
                 ) from exc
 
             # Design voices validated lazily at synthesis time
             speaker_voices[speaker] = ResolvedVoice(kind="design", value=canonicalized)
             _logger.info(
-                f"[TRACE] Speaker {speaker!r} resolved to design voice: {voice!r} -> {canonicalized!r}"
+                "[TRACE] Speaker %r resolved to design voice: %r -> %r",
+                speaker,
+                voice,
+                canonicalized,
             )
 
         _logger.info(
-            f"[TRACE] _resolve_voices completed: {len(speaker_voices)} unique speakers resolved"
+            "[TRACE] _resolve_voices completed: %d unique speakers",
+            len(speaker_voices),
         )
         for spk, rv in speaker_voices.items():
             _logger.info(
-                f"  - {spk!r}: kind={rv.kind}, value={rv.value!r}, ref_audio_path={rv.ref_audio_path}"
+                "  - %r: kind=%s, value=%r, ref_audio_path=%s",
+                spk,
+                rv.kind,
+                rv.value,
+                rv.ref_audio_path,
             )
         return speaker_voices
 

--- a/tests/test_issue_21_reproduction.py
+++ b/tests/test_issue_21_reproduction.py
@@ -3,7 +3,7 @@ Reproduction test for Issue #21: Voice Clone Bug
 https://github.com/maemreyo/omnivoice-server/issues/21
 
 Bug description:
-- Clone voice not working - two male voices when using clone:<male_profile> and clone:<female_profile>
+- Clone not working - two male voices when using clone:male_profile and clone:female_profile
 - Voice inconsistency - same transcript produces different voices each generation
 - Wrong gender output - Voice ID like "ash" produces wrong gender
 
@@ -34,7 +34,6 @@ def test_script_clone_two_speakers_two_different_profiles(client, sample_audio_b
     EXPECTED: alice should use male_profile, bob should use female_profile
     ACTUAL (BUG): Both use the same profile or one falls back to design mode
     """
-    import json
 
     # Create male profile
     resp = client.post(
@@ -125,7 +124,7 @@ def test_speech_clone_single_profile(client, sample_audio_bytes):
     # Check the synthesize mock
     synthesize_call = client.app.state.inference_svc.synthesize.call_args
     req = synthesize_call[0][0]
-    print(f"\nSynthesisRequest:")
+    print("\nSynthesisRequest:")
     print(f"  text: {req.text!r}")
     print(f"  mode: {req.mode}")
     print(f"  ref_audio_path: {req.ref_audio_path}")
@@ -185,8 +184,9 @@ def test_script_clone_same_profile_different_speakers(client, sample_audio_bytes
 
 if __name__ == "__main__":
     # Run manually with pytest to see trace output
-    import pytest
     import sys
+
+    import pytest
 
     # Run with -s -v to see print statements and trace logging
     sys.exit(pytest.main([__file__, "-s", "-v", "--log-cli-level=DEBUG"]))


### PR DESCRIPTION
## Summary
- Fix mypy: remove unsupported include_url param in RequestValidationError.errors()
- Fix ruff E501: reduce long lines in speech.py, inference.py, script.py  
- Fix ruff F401/F821: unused import and undefined io in test file
- Fix ruff F541: f-string without placeholders

## Additional
- Add pre-commit hook for local CI checks (mypy + ruff before commit)